### PR TITLE
Rectangles with cool box-drawed borders

### DIFF
--- a/examples/styled-rect.rs
+++ b/examples/styled-rect.rs
@@ -1,0 +1,14 @@
+use console_engine::screen;
+use console_engine::rect_style::BorderStyle;
+
+fn main() {
+    let mut scr = screen::Screen::new(9, 10);
+
+    scr.rect_border(0, 0, 3, 2, BorderStyle::new_simple());
+    scr.rect_border(0, 3, 3, 5, BorderStyle::new_light());
+    scr.rect_border(4, 0, 7, 2, BorderStyle::new_heavy());
+    scr.rect_border(4, 3, 7, 5, BorderStyle::new_double());
+
+    // print the screen to the terminal
+    scr.draw();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub extern crate crossterm;
 
 pub mod pixel;
 pub mod screen;
+pub mod rect_style;
 mod utils;
 
 pub use crossterm::event::{KeyCode, KeyModifiers, MouseButton};
@@ -19,6 +20,7 @@ use crossterm::{
 };
 use crossterm::{execute, queue, style};
 use pixel::Pixel;
+use rect_style::BorderStyle;
 use screen::Screen;
 use std::io::Write;
 use std::io::{stdout, Stdout};
@@ -302,6 +304,18 @@ impl ConsoleEngine {
     /// ```
     pub fn rect(&mut self, start_x: i32, start_y: i32, end_x: i32, end_y: i32, character: Pixel) {
         self.screen.rect(start_x, start_y, end_x, end_y, character)
+    }
+
+    /// Draws a rectangle with custom borders of the provided between two sets of coordinates. Check the BorderStyle struct to learn how to use built-in or custom styles
+    /// 
+    /// usage:
+    /// ```
+    /// use console_engine::rect_style::BorderStyle;
+    /// // ...
+    /// screen.rect_border(0, 0, 9, 9, BorderStyle::new_simple());
+    /// ```
+    pub fn rect_border(&mut self, start_x: i32, start_y: i32, end_x: i32, end_y: i32, rect_style: BorderStyle) {
+        self.screen.rect_border(start_x, start_y, end_x, end_y, rect_style)
     }
 
     /// Fill a rectangle of the provided character between two sets of coordinates

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,7 +312,7 @@ impl ConsoleEngine {
     /// ```
     /// use console_engine::rect_style::BorderStyle;
     /// // ...
-    /// screen.rect_border(0, 0, 9, 9, BorderStyle::new_simple());
+    /// engine.rect_border(0, 0, 9, 9, BorderStyle::new_simple());
     /// ```
     pub fn rect_border(&mut self, start_x: i32, start_y: i32, end_x: i32, end_y: i32, rect_style: BorderStyle) {
         self.screen.rect_border(start_x, start_y, end_x, end_y, rect_style)

--- a/src/rect_style.rs
+++ b/src/rect_style.rs
@@ -1,0 +1,82 @@
+use crate::pixel::{self, Pixel};
+
+/// Borders for styled-border rectangle
+#[derive(Copy, Clone)]
+pub struct BorderStyle {
+    pub corner_top_left: Pixel,
+    pub corner_top_right: Pixel,
+    pub corner_bottom_left: Pixel,
+    pub corner_bottom_right: Pixel,
+    pub top_bottom: Pixel,
+    pub left_right: Pixel,
+}
+
+impl BorderStyle {
+
+    /// Simple border (uses only ascii characters +, -, |)
+    pub fn new_simple() -> Self {
+        Self {
+            corner_top_right: pixel::pxl('+'),
+            corner_top_left: pixel::pxl('+'),
+            corner_bottom_left: pixel::pxl('+'),
+            corner_bottom_right: pixel::pxl('+'),
+            top_bottom: pixel::pxl('-'),
+            left_right: pixel::pxl('|'),
+        }
+    }
+
+    /// Light border (uses Box Drawings Light set from unicode)
+    pub fn new_light() -> Self {
+        Self {
+            corner_top_right: pixel::pxl('┐'),
+            corner_top_left: pixel::pxl('┌'),
+            corner_bottom_left: pixel::pxl('└'),
+            corner_bottom_right: pixel::pxl('┘'),
+            top_bottom: pixel::pxl('─'),
+            left_right: pixel::pxl('│'),
+        }
+    }
+
+    /// Heavy border (uses Box Drawings Heavy set from unicode)
+    pub fn new_heavy() -> Self {
+        Self {
+            corner_top_right: pixel::pxl('┓'),
+            corner_top_left: pixel::pxl('┏'),
+            corner_bottom_left: pixel::pxl('┗'),
+            corner_bottom_right: pixel::pxl('┛'),
+            top_bottom: pixel::pxl('━'),
+            left_right: pixel::pxl('┃'),
+        }
+    }
+
+    /// Double border (uses Box Drawings Double set from unicode)
+    pub fn new_double() -> Self {
+        Self {
+            corner_top_right: pixel::pxl('╗'),
+            corner_top_left: pixel::pxl('╔'),
+            corner_bottom_left: pixel::pxl('╚'),
+            corner_bottom_right: pixel::pxl('╝'),
+            top_bottom: pixel::pxl('═'),
+            left_right: pixel::pxl('║'),
+        }
+    }
+
+    /// Creates user-defined border style with specified Pixel's structs
+    pub fn new(
+        corner_top_left: Pixel,
+        corner_top_right: Pixel,
+        corner_bottom_left: Pixel,
+        corner_bottom_right: Pixel,
+        top_bottom: Pixel,
+        left_right: Pixel,
+    ) -> Self {
+        Self {
+            corner_top_right,
+            corner_top_left,
+            corner_bottom_left,
+            corner_bottom_right,
+            top_bottom,
+            left_right,
+        }
+    }
+}

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,5 +1,7 @@
 //! Standalone screens
 
+use crate::rect_style::BorderStyle;
+
 use super::crossterm::style::Color;
 use super::crossterm::{execute, style};
 use super::pixel;
@@ -373,6 +375,33 @@ impl Screen {
         self.v_line(end_x, start_y, end_y, character); // right
         self.h_line(end_x, end_y, start_x, character); // bottom
         self.v_line(start_x, end_y, start_y, character); // left
+    }
+
+    /// Draws a rectangle with custom borders of the provided between two sets of coordinates. Check the BorderStyle struct to learn how to use built-in or custom styles
+    /// 
+    /// usage:
+    /// ```
+    /// use console_engine::rect_style::BorderStyle;
+    /// // ...
+    /// screen.rect_border(0, 0, 9, 9, BorderStyle::new_simple());
+    /// ```
+    pub fn rect_border(
+        &mut self,
+        start_x: i32,
+        start_y: i32,
+        end_x: i32,
+        end_y: i32,
+        rect_style: BorderStyle,
+    ) {
+        self.h_line(start_x, start_y, end_x, rect_style.top_bottom); // top
+        self.v_line(end_x, start_y, end_y, rect_style.left_right); // right
+        self.h_line(end_x, end_y, start_x, rect_style.top_bottom); // bottom
+        self.v_line(start_x, end_y, start_y, rect_style.left_right); // top left
+        // borders
+        self.set_pxl(start_x, start_y, rect_style.corner_top_left); // top left corner
+        self.set_pxl(end_x, start_y, rect_style.corner_top_right); // top right corner
+        self.set_pxl(start_x, end_y, rect_style.corner_bottom_left); // bottom left corner
+        self.set_pxl(end_x, end_y, rect_style.corner_bottom_right); // bottom right corner
     }
 
     /// Fill a rectangle of the provided character between two sets of coordinates  


### PR DESCRIPTION
The ```rect_border()``` function allows to draw rects with styled border (useful for box-drawing symbols). 

There is some built-in rect styles (check the styled-rect example)

![Styled-borders](https://i.imgur.com/runxpLk.png)

Also, developer can create a custom style struct with ```BorderStyle::new()``` respectively.