### PR TITLE
Flush resize event from startup + address clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 authors = ["Vincent Foulon <sup.vfoulon@gmail.com>"]
+categories = ["command-line-interface"]
 description = "A simple terminal framework to draw things and manage user input"
 edition = "2021"
 include = ["src/**/*", "LICENSE", "README.md"]
@@ -8,7 +9,7 @@ license = "MIT"
 name = "console_engine"
 readme = "README.md"
 repository = "https://github.com/VincentFoulon80/console_engine"
-version = "2.5.0"
+version = "2.5.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]

--- a/src/forms/constraints/numbers.rs
+++ b/src/forms/constraints/numbers.rs
@@ -24,11 +24,11 @@ impl FormConstraint for Integer {
                     return false;
                 }
                 if let Some(chr) = value.chars().next() {
-                    if !chr.is_digit(10) && chr != '-' && chr != '+' {
+                    if !chr.is_ascii_digit() && chr != '-' && chr != '+' {
                         return false;
                     }
                 }
-                value.chars().skip(1).all(|x| x.is_digit(10))
+                value.chars().skip(1).all(|x| x.is_ascii_digit())
             }
             FormValue::Map(entries) => entries.iter().all(|(_, x)| self.validate(x)),
             FormValue::List(entries) => entries

--- a/src/forms/text.rs
+++ b/src/forms/text.rs
@@ -68,7 +68,7 @@ impl Text {
         }
         self.dirty = true;
         let off_l = amount.max(0) as usize; // offset to the left from cursor, `positive` or 0
-        let off_r = amount.min(0).abs() as usize; // offset to the right from cursor,  `-negative` or 0
+        let off_r = amount.min(0).unsigned_abs() as usize; // offset to the right from cursor,  `-negative` or 0
         let pos_l = self.cursor_pos.saturating_sub(off_l);
         let pos_r = self
             .cursor_pos
@@ -270,7 +270,7 @@ impl HiddenText {
         }
         self.dirty = true;
         let off_l = amount.max(0) as usize; // offset to the left from cursor, `positive` or 0
-        let off_r = amount.min(0).abs() as usize; // offset to the right from cursor,  `-negative` or 0
+        let off_r = amount.min(0).unsigned_abs() as usize; // offset to the right from cursor,  `-negative` or 0
         let pos_l = self.cursor_pos.saturating_sub(off_l);
         let pos_r = self
             .cursor_pos

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,13 @@ impl ConsoleEngine {
                 crossterm::terminal::SetSize(width as u16, height as u16)
             )?;
             self.resize(width, height);
+            // flush events
+            #[cfg(feature = "event")]
+            use std::time::Duration;
+            #[cfg(feature = "event")]
+            while let Ok(true) = event::poll(Duration::from_micros(100)) {
+                event::read().ok();
+            }
         }
         if crossterm::terminal::size()? < (width as u16, height as u16) {
             Err(ErrorKind::new(std::io::ErrorKind::Other, format!("Your terminal must have at least a width and height of {}x{} characters. Currently has {}x{}", width, height, size.0, size.1)))

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -679,7 +679,7 @@ impl Screen {
                     }
                 }
             } else {
-                let step = h_scroll.abs() as usize;
+                let step = h_scroll.unsigned_abs() as usize;
                 // scroll to the right
                 for j in 0..height {
                     // move the pixels
@@ -813,8 +813,8 @@ impl Screen {
         end_y: i32,
         default: Pixel,
     ) -> Screen {
-        let target_width = (end_x - start_x).abs() as u32 + 1;
-        let target_height = (end_y - start_y).abs() as u32 + 1;
+        let target_width = (end_x - start_x).unsigned_abs() + 1;
+        let target_height = (end_y - start_y).unsigned_abs() + 1;
         let mut extracted_screen = vec![default; (target_width * target_height) as usize];
         let x_reversed = start_x > end_x;
         let y_reversed = start_y > end_y;


### PR DESCRIPTION
# 🐞 Bugfixes

- Flush events on startup due to a bug where polling an event would show undesired resize events
- Addressed clippy warnings