### PR TITLE
Update crossterm to 0.26.1 (fixed examples and add proper key release)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "2.5.1"
 doctest = false
 
 [dependencies]
-crossterm = "0.24"
+crossterm = "0.26.1"
 unicode-width = "0.1.8"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ See [examples](https://github.com/VincentFoulon80/console_engine/tree/master/exa
 - **screen-simple** : Example usage of Screen struct instead of ConsoleEngine
 - **screen-swap** : Swap between several Screen structures
 - **scroll** : Example for the `scroll` function
+- **scroll-smooth** : Example for smooth scrolling (windows only as of crossterm 0.26.1)
 - **shapes** : Shape's functions testing tool
 - **snake** : A simple game of snake.
 - **styled-rect** : Example of the `rect_border` function

--- a/examples/form-choices.rs
+++ b/examples/form-choices.rs
@@ -75,6 +75,8 @@ fn main() {
             Event::Key(KeyEvent {
                 code: KeyCode::Esc,
                 modifiers: _,
+                kind: _,
+                state: _,
             }) => {
                 break;
             }
@@ -82,6 +84,8 @@ fn main() {
             Event::Key(KeyEvent {
                 code: KeyCode::Char('c'),
                 modifiers: KeyModifiers::CONTROL,
+                kind: _,
+                state: _,
             }) => {
                 break;
             }

--- a/examples/form-simple.rs
+++ b/examples/form-simple.rs
@@ -64,6 +64,8 @@ fn main() {
             Event::Key(KeyEvent {
                 code: KeyCode::Esc,
                 modifiers: _,
+                kind: _,
+                state: _,
             }) => {
                 break;
             }
@@ -72,6 +74,8 @@ fn main() {
             Event::Key(KeyEvent {
                 code: KeyCode::Char('c'),
                 modifiers: KeyModifiers::CONTROL,
+                kind: _,
+                state: _,
             }) => {
                 break;
             }

--- a/examples/form-text.rs
+++ b/examples/form-text.rs
@@ -4,7 +4,7 @@ use console_engine::{
     rect_style::BorderStyle,
     KeyCode,
 };
-use crossterm::event::KeyEvent;
+use crossterm::event::{KeyEvent, KeyEventKind};
 
 fn main() {
     // initializes the engine
@@ -36,6 +36,8 @@ fn main() {
             Event::Key(KeyEvent {
                 code: KeyCode::Enter | KeyCode::Esc,
                 modifiers: _,
+                kind: KeyEventKind::Press,
+                state: _,
             }) => {
                 break;
             }

--- a/examples/form-validation.rs
+++ b/examples/form-validation.rs
@@ -57,6 +57,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             Event::Key(KeyEvent {
                 code: KeyCode::Esc,
                 modifiers: _,
+                kind: _,
+                state: _,
             }) => {
                 break;
             }
@@ -64,6 +66,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             Event::Key(KeyEvent {
                 code: KeyCode::Char('c'),
                 modifiers: KeyModifiers::CONTROL,
+                kind: _,
+                state: _,
             }) => {
                 break;
             }

--- a/examples/scroll-smooth.rs
+++ b/examples/scroll-smooth.rs
@@ -56,6 +56,7 @@ fn main() {
             y = 0;
         }
 
+        // is_key_released is windows only as of crossterm 0.26.1
         // sometimes going the opposite direction will incorrectly trigger this code
         if engine.is_key_released(KeyCode::Up) && y == -1
             || engine.is_key_released(KeyCode::Down) && y == 1

--- a/examples/scroll-smooth.rs
+++ b/examples/scroll-smooth.rs
@@ -1,0 +1,74 @@
+use console_engine::pixel;
+use console_engine::Color;
+use console_engine::KeyCode;
+
+fn main() {
+    let (mut x, mut y) = (0, 0);
+    // initializes a screen of 30x20 characters with a target of 3 frames per second
+    // coordinates will range from [0,0] to [29,19]
+    let mut engine = console_engine::ConsoleEngine::init(30, 20, 10).unwrap();
+    // draw the background
+    engine.fill(pixel::pxl_bg(' ', Color::Cyan));
+    // draw the window background
+    engine.fill_rect(
+        5,
+        5,
+        engine.get_width() as i32 - 5,
+        engine.get_height() as i32 - 5,
+        pixel::pxl_bg(' ', Color::White),
+    );
+    // draw the window borders
+    engine.rect(
+        5,
+        5,
+        engine.get_width() as i32 - 5,
+        engine.get_height() as i32 - 5,
+        pixel::pxl_bg(' ', Color::Blue),
+    );
+    // write something to the window
+    engine.print_fbg(7, 7, "push arrows", Color::Black, Color::White);
+    engine.print_fbg(7, 8, "to scroll", Color::Black, Color::White);
+    engine.print_fbg(7, 9, "q to quit", Color::Black, Color::White);
+
+    // main loop, be aware that you'll have to break it because ctrl+C is captured
+    loop {
+        engine.wait_frame(); // wait for next frame + capture inputs
+
+        if engine.is_key_pressed(KeyCode::Char('q')) {
+            // if the user presses 'q' :
+            break; // exits app
+        }
+
+        if engine.is_key_held(KeyCode::Up) {
+            y = -1;
+            x = 0;
+        }
+        if engine.is_key_held(KeyCode::Down) {
+            y = 1;
+            x = 0;
+        }
+        if engine.is_key_held(KeyCode::Left) {
+            x = -1;
+            y = 0;
+        }
+        if engine.is_key_held(KeyCode::Right) {
+            x = 1;
+            y = 0;
+        }
+
+        // sometimes going the opposite direction will incorrectly trigger this code
+        if engine.is_key_released(KeyCode::Up) && y == -1
+            || engine.is_key_released(KeyCode::Down) && y == 1
+        {
+            y = 0;
+        }
+        if engine.is_key_released(KeyCode::Left) && x == -1
+            || engine.is_key_released(KeyCode::Right) && x == 1
+        {
+            x = 0;
+        }
+
+        engine.scroll(x, y, pixel::pxl_bg(' ', Color::Cyan)); // continually update x and y
+        engine.draw(); // draw the screen
+    }
+}

--- a/src/forms/choices.rs
+++ b/src/forms/choices.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
 
 use crate::{events::Event, pixel, screen::Screen};
 
@@ -95,7 +95,13 @@ impl FormField for Radio {
         if !self.active {
             return;
         }
-        if let Event::Key(KeyEvent { code, modifiers: _ }) = event {
+        if let Event::Key(KeyEvent {
+            code,
+            modifiers: _,
+            kind: KeyEventKind::Press,
+            state: _,
+        }) = event
+        {
             match code {
                 KeyCode::Up => self.move_cursor(-1),
                 KeyCode::Down => self.move_cursor(1),
@@ -260,7 +266,13 @@ impl FormField for Checkbox {
         if !self.active {
             return;
         }
-        if let Event::Key(KeyEvent { code, modifiers: _ }) = event {
+        if let Event::Key(KeyEvent {
+            code,
+            modifiers: _,
+            kind: KeyEventKind::Press,
+            state: _,
+        }) = event
+        {
             match code {
                 KeyCode::Up => self.move_cursor(-1),
                 KeyCode::Down => self.move_cursor(1),

--- a/src/forms/form.rs
+++ b/src/forms/form.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Borrow, collections::HashMap};
 
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
 
 use crate::{events::Event, pixel, screen::Screen};
 
@@ -208,7 +208,13 @@ impl FormField for Form {
         if !self.active {
             return;
         }
-        if let Event::Key(KeyEvent { code, modifiers: _ }) = event {
+        if let Event::Key(KeyEvent {
+            code,
+            modifiers: _,
+            kind: KeyEventKind::Press,
+            state: _,
+        }) = event
+        {
             match code {
                 KeyCode::Enter => {
                     self.index = (self.index + 1).clamp(0, self.fields.len());

--- a/src/forms/text.rs
+++ b/src/forms/text.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 use crate::{events::Event, pixel, screen::Screen};
 
@@ -118,7 +118,13 @@ impl FormField for Text {
         if !self.active {
             return;
         }
-        if let Event::Key(KeyEvent { code, modifiers }) = event {
+        if let Event::Key(KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            state: _,
+        }) = event
+        {
             match code {
                 KeyCode::Backspace => self.remove_char(1),
                 KeyCode::Delete => self.remove_char(-1),
@@ -317,7 +323,13 @@ impl FormField for HiddenText {
         if !self.active {
             return;
         }
-        if let Event::Key(KeyEvent { code, modifiers }) = event {
+        if let Event::Key(KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            state: _,
+        }) = event
+        {
             match code {
                 KeyCode::Backspace => self.remove_char(1),
                 KeyCode::Delete => self.remove_char(-1),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -752,9 +752,9 @@ impl ConsoleEngine {
                             Event::Key(evt) => return events::Event::Key(evt),
                             Event::Mouse(evt) => return events::Event::Mouse(evt),
                             Event::Resize(w, h) => return events::Event::Resize(w, h),
-                            Event::FocusGained => todo!(),
-                            Event::FocusLost => todo!(),
-                            Event::Paste(_) => todo!(),
+                            Event::FocusGained => (),
+                            Event::FocusLost => (),
+                            Event::Paste(_) => (),
                         };
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod events;
 #[cfg(feature = "form")]
 pub mod forms;
 
+use crossterm::event::KeyEventKind;
 pub use crossterm::event::{KeyCode, KeyModifiers, MouseButton};
 pub use crossterm::style::Color;
 use crossterm::terminal::{self, ClearType};
@@ -686,6 +687,9 @@ impl ConsoleEngine {
                             Event::Resize(w, h) => {
                                 captured_resize.push((w, h));
                             }
+                            Event::FocusGained => todo!(),
+                            Event::FocusLost => todo!(),
+                            Event::Paste(_) => todo!(),
                         };
                     }
                 }
@@ -749,6 +753,9 @@ impl ConsoleEngine {
                             Event::Key(evt) => return events::Event::Key(evt),
                             Event::Mouse(evt) => return events::Event::Mouse(evt),
                             Event::Resize(w, h) => return events::Event::Resize(w, h),
+                            Event::FocusGained => todo!(),
+                            Event::FocusLost => todo!(),
+                            Event::Paste(_) => todo!(),
                         };
                     }
                 }
@@ -803,7 +810,7 @@ impl ConsoleEngine {
     /// }
     /// ```
     pub fn is_key_pressed(&self, key: KeyCode) -> bool {
-        self.is_key_pressed_with_modifier(key, KeyModifiers::NONE)
+        self.is_key_pressed_with_modifier(key, KeyModifiers::NONE, KeyEventKind::Press)
     }
 
     /// checks whenever a key + a modifier (ctrl, shift...) is pressed (first frame held only)
@@ -820,8 +827,14 @@ impl ConsoleEngine {
     ///     }
     /// }
     /// ```
-    pub fn is_key_pressed_with_modifier(&self, key: KeyCode, modifier: KeyModifiers) -> bool {
-        self.keys_pressed.contains(&KeyEvent::new(key, modifier))
+    pub fn is_key_pressed_with_modifier(
+        &self,
+        key: KeyCode,
+        modifier: KeyModifiers,
+        kind: KeyEventKind,
+    ) -> bool {
+        self.keys_pressed
+            .contains(&KeyEvent::new_with_kind(key, modifier, kind))
     }
 
     /// checks whenever a key is held down
@@ -839,12 +852,18 @@ impl ConsoleEngine {
     /// }
     /// ```
     pub fn is_key_held(&self, key: KeyCode) -> bool {
-        self.is_key_held_with_modifier(key, KeyModifiers::NONE)
+        self.is_key_held_with_modifier(key, KeyModifiers::NONE, KeyEventKind::Press)
     }
 
     /// checks whenever a key + a modifier (ctrl, shift...) is held down
-    pub fn is_key_held_with_modifier(&self, key: KeyCode, modifier: KeyModifiers) -> bool {
-        self.keys_held.contains(&KeyEvent::new(key, modifier))
+    pub fn is_key_held_with_modifier(
+        &self,
+        key: KeyCode,
+        modifier: KeyModifiers,
+        kind: KeyEventKind,
+    ) -> bool {
+        self.keys_held
+            .contains(&KeyEvent::new_with_kind(key, modifier, kind))
     }
 
     /// checks whenever a key has been released (first frame released)
@@ -863,12 +882,18 @@ impl ConsoleEngine {
     /// }
     /// ```
     pub fn is_key_released(&self, key: KeyCode) -> bool {
-        self.is_key_released_with_modifier(key, KeyModifiers::NONE)
+        self.is_key_released_with_modifier(key, KeyModifiers::NONE, KeyEventKind::Release)
     }
 
     /// checks whenever a key + a modifier (ctrl, shift...) has been released (first frame released)
-    pub fn is_key_released_with_modifier(&self, key: KeyCode, modifier: KeyModifiers) -> bool {
-        self.keys_released.contains(&KeyEvent::new(key, modifier))
+    pub fn is_key_released_with_modifier(
+        &self,
+        key: KeyCode,
+        modifier: KeyModifiers,
+        kind: KeyEventKind,
+    ) -> bool {
+        self.keys_released
+            .contains(&KeyEvent::new_with_kind(key, modifier, kind))
     }
 
     /// Give the mouse's terminal coordinates if the provided button has been pressed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,7 @@ pub mod events;
 #[cfg(feature = "form")]
 pub mod forms;
 
-use crossterm::event::KeyEventKind;
-pub use crossterm::event::{KeyCode, KeyModifiers, MouseButton};
+pub use crossterm::event::{KeyCode, KeyEventKind, KeyModifiers, MouseButton};
 pub use crossterm::style::Color;
 use crossterm::terminal::{self, ClearType};
 use crossterm::{
@@ -687,9 +686,9 @@ impl ConsoleEngine {
                             Event::Resize(w, h) => {
                                 captured_resize.push((w, h));
                             }
-                            Event::FocusGained => todo!(),
-                            Event::FocusLost => todo!(),
-                            Event::Paste(_) => todo!(),
+                            Event::FocusGained => (),
+                            Event::FocusLost => (),
+                            Event::Paste(_) => (),
                         };
                     }
                 }


### PR DESCRIPTION
I didn't implement window focus or paste because I'm not sure how, it just returns () now so it doesn't panic.

There's also a new `KeyEventState` which I didn't use because I think it requires kitty keyboard protocol in order to work. Which windows terminal/conhost doesn't support so maybe leave it for now.

Lastly I noticed that in `--example shapes` holding down S or F which checks for key press not hold does the action a second time after a few frames. But this happens in crossterm 0.24 as well so it's unrelated to this.

Closes https://github.com/VincentFoulon80/console_engine/issues/16 you could make a new issues for window focus, paste and the double key press? Fixes https://github.com/VincentFoulon80/console_engine/issues/22

This change now allows for smooth movement using console engine like I was trying to get in my issue 👍 .