### PR TITLE
Allow users to handle terminal size errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "console_engine"
 readme = "README.md"
 repository = "https://github.com/VincentFoulon80/console_engine"
-version = "2.6.0"
+version = "2.6.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ impl ConsoleEngine {
 
     /// Initialize a screen filling the entire terminal with the target FPS
     pub fn init_fill(target_fps: u32) -> Result<ConsoleEngine, ErrorKind> {
-        let size = crossterm::terminal::size().unwrap();
+        let size = crossterm::terminal::size()?;
         ConsoleEngine::init(size.0 as u32, size.1 as u32, target_fps)
     }
 


### PR DESCRIPTION
I stumbled onto an issue when using TeamCity to run test suites, and found that it would panic when attempting to run the test suite, since the size couldn't be resolved.

This PR will allow users to handle this case instead of panic. Otherwise TeamCity build agents cannot test any applications using the console_engine crate.